### PR TITLE
Adds Chainstack to supported RPC providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Create another file called `.env` in your repo's top-level directory, or add the
 # Must fill in one of these API keys, do not need both
 GUARDIAN_UI_INFURA_API_KEY=
 GUARDIAN_UI_ALCHEMY_API_KEY=
+GUARDIAN_UI_CHAINSTACK_API_KEY=
 ```
 
 **package.json**

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you already are using Playwright and already have a `playwright.config.ts`:
 Create another file called `.env` in your repo's top-level directory, or add the following to your existing `.env` file if you already have one. Comment out whichever line you do not use with a `#` at the start.
 
 ```bash
-# Must fill in one of these API keys, do not need both
+# Must fill in one of these API keys; only need one
 GUARDIAN_UI_INFURA_API_KEY=
 GUARDIAN_UI_ALCHEMY_API_KEY=
 GUARDIAN_UI_CHAINSTACK_API_KEY=

--- a/src/models/GUI.ts
+++ b/src/models/GUI.ts
@@ -123,7 +123,8 @@ export class GUI {
      */
     async initializeChain(chainId: number, forkBlockNumber?: number) {
         // If a GuardianUI RPC cache url is provided, use it. Otherwise, if an Alchemy RPC key is provided
-        // use it. Otherwise, if an Infura RPC key is provided use that. Otherwise throw an error.
+        // use it. Otherwise, if an Infura RPC key is provided use that. 
+        // Otherwise, if an Chainstack RPC key is provided use that. Otherwise throw an error.
         let forkRpc;
         const rpcCacheUrl = this.getCacheUrl(chainId);
         if (rpcCacheUrl) {

--- a/src/models/GUI.ts
+++ b/src/models/GUI.ts
@@ -132,6 +132,8 @@ export class GUI {
             forkRpc = getAlchemyRpcUrl(chainId, process.env.GUARDIAN_UI_ALCHEMY_API_KEY);
         } else if (process.env.GUARDIAN_UI_INFURA_API_KEY) {
             forkRpc = getInfuraRpcUrl(chainId, process.env.GUARDIAN_UI_INFURA_API_KEY);
+        } else if (process.env.GUARDIAN_UI_CHAINSTACK_API_KEY) {
+            forkRpc = getChainstackRpcUrl(chainId, process.env.GUARDIAN_UI_CHAINSTACK_API_KEY);
         } else {
             throw new Error("No RPC key provided");
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ export const isMainnetRPC = (url: URL): boolean => {
         url.hostname === "mainnet.infura.io" ||
         url.hostname === "eth-mainnet.g.alchemy.com" ||
         url.hostname === "eth.llamarpc.com" ||
+        url.hostname === "ethereum-mainnet.core.chainstack.com" ||
         url.hostname === "eth-rpc.gateway.pokt.network" ||
         url.hostname === "eth-archival.gateway.pokt.network" ||
         url.hostname === "eth-mainnet.alchemyapi.io" ||
@@ -37,6 +38,7 @@ export const isArbiRPC = (url: URL): boolean => {
         url.hostname === "arb-mainnet.g.alchemy.com" ||
         url.hostname === "arbitrum-rpc.gateway.pokt.network" ||
         url.hostname === "arb-mainnet.alchemyapi.io" ||
+        url.hostname === "arbitrum-mainnet.core.chainstack.com" ||
         (url.hostname === "rpc.ankr.com" && url.pathname === "/arbitrum")
     ) {
         return true;
@@ -55,6 +57,7 @@ export const isOptiRPC = (url: URL): boolean => {
         url.hostname === "optimism-mainnet.infura.io" ||
         url.hostname === "opt-mainnet.g.alchemy.com" ||
         url.hostname === "optimism-rpc.gateway.pokt.network" ||
+        url.hostname === "optimism-mainnet.core.chainstack.com" ||
         url.hostname === "opt-mainnet.alchemyapi.io" ||
         (url.hostname === "rpc.ankr.com" && url.pathname === "/optimism")
     ) {
@@ -74,6 +77,7 @@ export const isPolyRPC = (url: URL): boolean => {
         url.hostname === "polygon-mainnet.infura.io" ||
         url.hostname === "polygon-mainnet.g.alchemy.com" ||
         url.hostname === "poly-rpc.gateway.pokt.network" ||
+        url.hostname === "polygon-mainnet.core.chainstack.com" ||
         url.hostname === "polygon-mainnet.alchemyapi.io" ||
         (url.hostname === "rpc.ankr.com" && url.pathname === "/polygon")
     ) {
@@ -122,6 +126,28 @@ export const getInfuraRpcUrl = (networkId: number, apiKey: string): string => {
             return `https://optimism-mainnet.infura.io/v3/${apiKey}`
         case 137: // Polygon
             return `https://polygon-mainnet.infura.io/v3/${apiKey}`
+        default:
+            throw new Error(`Network ID ${networkId} not supported`);
+    }
+}
+
+/**
+ * Maps a given network ID and API key to an Chainstack RPC URL
+ * @param networkId - The chain's network ID
+ * @param apiKey - The Chainstack API key
+ * @returns The Chainstack RPC URL
+ * @throws If the network ID is not supported
+ */
+export const getChainstackRpcUrl = (networkId: number, apiKey: string): string => {
+    switch (networkId) {
+        case 1: // Mainnet
+            return `https://ethereum-mainnet.core.chainstack.com/${apiKey}`
+        case 42161: // Arbitrum
+            return `https://arbitrum-mainnet.core.chainstack.com/${apiKey}`
+        case 10: // Optimism
+            return `https://optimism-mainnet.core.chainstack.com/${apiKey}`
+        case 137: // Polygon
+            return `https://polygon-mainnet.core.chainstack.com/${apiKey}`
         default:
             throw new Error(`Network ID ${networkId} not supported`);
     }

--- a/src/wallet/EIP1193Bridge.ts
+++ b/src/wallet/EIP1193Bridge.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
  * EIP-1193 Bridge
  * This is an implementation of the spec laid out by EIP-1193 to create an Ethereum Provider API
  * that widely used to promote wallet interoperability. It is a minimal API to handle incoming
- * requests from a dApp and pass them to an RPC provider (e.g. Infura, Alchemy, etc.) and return
+ * requests from a dApp and pass them to an RPC provider (e.g. Infura, Alchemy, Chainstack, etc.) and return
  * the result back to the dApp.
  * @see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md
  */


### PR DESCRIPTION
## Description

Includes Chainstack (specifically Chainstack's Global Elastic Endpoints) among Infura and Alchemy in RPC provider support.

## Additional Information

- [x] I read the [contributing docs](https://github.com/GuardianUI/guardianui/blob/main/CONTRIBUTING.md) (if this is your first contribution)
